### PR TITLE
proart-7950x: advertise as exit node

### DIFF
--- a/hosts/proart-7950x/tailscale.nix
+++ b/hosts/proart-7950x/tailscale.nix
@@ -15,9 +15,11 @@ in
     enable = true;
     openFirewall = true;
     authKeyFile = config.age.secrets.proart-tailscale-preauth-key.path;
+    useRoutingFeatures = "both";
     extraUpFlags = [
       "--login-server=${headscaleUrl}"
       "--accept-dns=true" # accept MagicDNS
+      "--advertise-exit-node"
     ];
   };
 }


### PR DESCRIPTION
I also had to follow https://headscale.net/0.24.1/ref/exit-node/