### PR TITLE
proart-7950x: use github-runner from pkgs unstable

### DIFF
--- a/hosts/proart-7950x/configuration.nix
+++ b/hosts/proart-7950x/configuration.nix
@@ -34,6 +34,13 @@
     firewall.allowedUDPPorts = [ 9 ];
   };
 
+  nixpkgs = {
+    overlays = [
+      inputs.self.overlays.unstable-packages
+    ];
+    hostPlatform = "x86_64-linux";
+  };
+
   environment.systemPackages = with pkgs; [
     ghostty # for the 'xterm-ghostty': unknown terminal type
   ];

--- a/hosts/proart-7950x/github-runners.nix
+++ b/hosts/proart-7950x/github-runners.nix
@@ -6,6 +6,9 @@
 
   services.github-runners.dvcorreia-nix-config = {
     enable = true;
+    package = pkgs.unstable.github-runner;
+    nodeRuntimes = [ "node24" ];
+
     name = "proart-7950x";
     url = "https://github.com/dvcorreia/nix-config";
 


### PR DESCRIPTION
The `github-runner` version that was running is deprecated.