### PR TITLE
chore: update flake inputs and nixpkgs to 26.05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ switch-home:
 	home-manager switch --flake .
 
 format:
-	nix-shell -p nixfmt-rfc-style --command "nixfmt **/*.nix"
+	nix-shell -p nixfmt --command "nixfmt **/*.nix"
 
 install/nix-darwin:
 	nix run $(NIX_OPTS) nix-darwin -- switch --flake ~/.config/nix-darwin

--- a/flake.lock
+++ b/flake.lock
@@ -49,16 +49,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769363988,
-        "narHash": "sha256-BiGPeulrDVetXP+tjxhMcGLUROZAtZIhU5m4MqawCfM=",
+        "lastModified": 1779646357,
+        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "d01011cac6d72032c75fd2cd9489909e95d9faf2",
+        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.0.12",
+        "ref": "5.1.14",
         "repo": "brew",
         "type": "github"
       }
@@ -92,16 +92,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773889306,
-        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "lastModified": 1780290312,
+        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
         "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1774286985,
-        "narHash": "sha256-6Vs3j9eo6jbXwK+IvJNTYrGEslzyKm6tjiNVdU8ryzA=",
+        "lastModified": 1780598390,
+        "narHash": "sha256-kU6kI70mN+16tb7rOf0l/u3lU8pH/sdZ9EaSOa0evLI=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "fa10237fb0cb952dcc5760339890e50f25818111",
+        "rev": "42fcd58dba54c2a0404c1c3d73c7d44081fac836",
         "type": "github"
       },
       "original": {
@@ -344,16 +344,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1774274588,
-        "narHash": "sha256-dnHvv5EMUgTzGZmA+3diYjQU2O6BEpGLEOgJ1Qe9LaY=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cf9686ba26f5ef788226843bc31fda4cf72e373b",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -361,11 +361,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1774287564,
-        "narHash": "sha256-x8feQrx9V+Wy/Ng052DUSdkDJ5mRqK8uRnWZmir1v4Q=",
+        "lastModified": 1780669082,
+        "narHash": "sha256-xnI9xOolwk8HdEZktVQvjxj9EZEIw3MdM/4jyfxB+Rg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "1496477d7c84d711d2e59f090f3d377257d88e77",
+        "rev": "bb1c280c78fd88f594c214d1dd30684e8daefaf2",
         "type": "github"
       },
       "original": {
@@ -377,11 +377,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1774291371,
-        "narHash": "sha256-NAGQr9s/PKwp531eNO2qTBr0yd4Yn13Wry1ULAvk0V0=",
+        "lastModified": 1780668019,
+        "narHash": "sha256-qj3F7p94H32XMUXSaVaFUm58ESwNUZJ6ov7jEJdA+Mw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "bd6f2a654dd6551c45d5208ccb3a0a9337e70063",
+        "rev": "954356bc72cea090dce4947de183241bb8869536",
         "type": "github"
       },
       "original": {
@@ -416,11 +416,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1769437432,
-        "narHash": "sha256-8d7KnCpT2LweRvSzZYEGd9IM3eFX+A78opcnDM0+ndk=",
+        "lastModified": 1780492467,
+        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "a5409abd0d5013d79775d3419bcac10eacb9d8c5",
+        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1774106199,
-        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -507,16 +507,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -654,11 +654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773145353,
-        "narHash": "sha256-dE8zx8WA54TRmFFQBvA48x/sXGDTP7YaDmY6nNKMAYw=",
+        "lastModified": 1776789209,
+        "narHash": "sha256-G6B7Q4TXn7MZ1mB+f9rymjsYF5PLWoSvmbxijb/99bw=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "8666155d83bf792956a7c40915508e6d4b2b8716",
+        "rev": "14fe971844e841297ddd2ce9783d6892b467af39",
         "type": "github"
       },
       "original": {
@@ -667,25 +667,48 @@
         "type": "github"
       }
     },
+    "zig_2": {
+      "inputs": {
+        "nixpkgs": [
+          "ghostty",
+          "zon2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777234348,
+        "narHash": "sha256-fKw44a4qbUuI5eTG8k0gPbqMV5TOrjYF35PBzsYgd2U=",
+        "ref": "refs/heads/main",
+        "rev": "2c781c0609ecda600ab98f98cca417bbd981bd53",
+        "revCount": 1677,
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      }
+    },
     "zon2nix": {
       "inputs": {
         "nixpkgs": [
           "ghostty",
           "nixpkgs"
-        ]
+        ],
+        "zig": "zig_2"
       },
       "locked": {
-        "lastModified": 1768231828,
-        "narHash": "sha256-wL/8Iij4T2OLkhHcc4NieOjf7YeJffaUYbCiCqKv/+0=",
+        "lastModified": 1777314365,
+        "narHash": "sha256-eLxQaD0wc96Neqkln8wHS0rNq/chPODifFkhwrwilEU=",
         "owner": "jcollie",
         "repo": "zon2nix",
-        "rev": "c28e93f3ba133d4c1b1d65224e2eebede61fd071",
+        "rev": "a5a1d412ad1ab6305511997bbc92b3a9dd6cb784",
         "type": "github"
       },
       "original": {
         "owner": "jcollie",
+        "ref": "main",
         "repo": "zon2nix",
-        "rev": "c28e93f3ba133d4c1b1d65224e2eebede61fd071",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,15 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     darwin = {
-      url = "github:LnL7/nix-darwin/nix-darwin-25.11";
+      url = "github:LnL7/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -55,7 +55,6 @@
     let
       supportedSystems = [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-linux"
         "aarch64-darwin"
       ];
@@ -72,7 +71,7 @@
         # be accessible through 'pkgs.unstable'
         unstable-packages = final: _prev: {
           unstable = import nixpkgs-unstable {
-            system = final.system;
+            system = final.stdenv.hostPlatform.system;
           };
         };
 

--- a/hosts/macbook-m3-pro/configuration.nix
+++ b/hosts/macbook-m3-pro/configuration.nix
@@ -185,8 +185,8 @@ in
       mutableTaps = true;
       user = "dvcorreia";
       taps = with inputs; {
-        "homebrew/homebrew-core" = homebrew-core;
-        "homebrew/homebrew-cask" = homebrew-cask;
+        "homebrew/homebrew-core" = inputs.homebrew-core;
+        "homebrew/homebrew-cask" = inputs.homebrew-cask;
       };
     };
 
@@ -206,6 +206,7 @@ in
     ];
     casks = [
       "ghostty"
+      "tailscale"
       "google-chrome"
       "brave-browser"
       "telegram"
@@ -225,11 +226,6 @@ in
       "signal"
       "jordanbaird-ice" # menu bar management tool
     ];
-
-    # MAS apps must have been installed or bought before on your Apple ID
-    masApps = {
-      Tailscale = 1475387142;
-    };
   };
 
   environment.systemPackages = with pkgs; [
@@ -247,7 +243,6 @@ in
     jetbrains-mono
     mononoki
     fira
-    iosevka
   ];
 
   system.stateVersion = 5;

--- a/hosts/proart-7950x/work.nix
+++ b/hosts/proart-7950x/work.nix
@@ -7,6 +7,9 @@
 }:
 
 # sometimes I need a linux machine to work
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+in
 {
   imports = [
     inputs.vscode-server.nixosModules.default
@@ -17,13 +20,14 @@
     builtins.elem (lib.getName pkg) [
       "vagrant"
       "Oracle_VirtualBox_Extension_Pack"
+      "virtualbox-extpack"
     ];
 
   environment.systemPackages = with pkgs; [
     git
     vagrant
     uv
-    inputs.nixpkgs-unstable.legacyPackages.${pkgs.system}.opencode
+    inputs.nixpkgs-unstable.legacyPackages.${system}.opencode
   ];
 
   # allow uv to run dynamically linked Python interpreters

--- a/hosts/sines/websites/dvcorreia_com.nix
+++ b/hosts/sines/websites/dvcorreia_com.nix
@@ -4,12 +4,15 @@
   ...
 }:
 
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+in
 {
   services.nginx.virtualHosts."dvcorreia.com" = {
     addSSL = true;
     enableACME = true;
 
-    root = "${inputs.dvcorreia-website.packages.${pkgs.system}.default}/share/dvcorreia-com";
+    root = "${inputs.dvcorreia-website.packages.${system}.default}/share/dvcorreia-com";
 
     locations."/" = {
       index = "index.html";

--- a/users/dvcorreia/default.nix
+++ b/users/dvcorreia/default.nix
@@ -40,7 +40,7 @@ in
 
     # The state version is required and should stay at the version you
     # originally installed. DO NOT CHANGE!
-    stateVersion = "24.05";
+    stateVersion = "26.05";
   };
 
   xdg.enable = true;
@@ -54,11 +54,11 @@ in
     tree
     watch
     ffmpeg
-    nixfmt-rfc-style
+    nixfmt
     unzip
     glow # markdown reader
 
-    nodePackages.typescript
+    typescript
     nodejs
   ];
 

--- a/users/dvcorreia/neovim.nix
+++ b/users/dvcorreia/neovim.nix
@@ -26,7 +26,7 @@
       ))
     ];
 
-    extraLuaConfig = ''
+    initLua = ''
       vim.g.mapleader = ' '
       vim.g.maplocalleader = ' '
 


### PR DESCRIPTION
Also adjusted a few things, namely:

- deprecate `x86_64-darwin`: RIP my old 2018 macbook pro
- removed `iosevka`: don't use it and was building things from source